### PR TITLE
Fix setup instructions for linux command line

### DIFF
--- a/Get-Started.md
+++ b/Get-Started.md
@@ -164,7 +164,7 @@ $ sudo chmod 666 /dev/ttyUSB0
 
 ![Check if serial device exists](//i.imgur.com/p1OwSE6h.png "Check if serial device exists")
 
-**Step 5**: Run `screen /dev/tty.SLAB_USBtoUART 115200` to connect to the Omega’s serial terminal using screen.
+**Step 5**: Run `screen /dev/ttyUSB0 115200` to connect to the Omega’s serial terminal using screen.
 
 ![Log in through serial terminal](//i.imgur.com/sENEIX8h.png "Log in through serial terminal")
 


### PR DESCRIPTION
I presume a copy and paste error was made since the device is called `/dev/ttyUSB0` on linux. Note that I was unable to get this working so I couldn't check if it is correct, but I am 99% sure that _this_ is the correct command.
