### PR TITLE
tutorial_ubus_part_3: add extra info for when rpcd reload does not work

### DIFF
--- a/Tutorials/OpenWrt Tutorials/UBUS_Tutorial/Part3_RPCD.md
+++ b/Tutorials/OpenWrt Tutorials/UBUS_Tutorial/Part3_RPCD.md
@@ -1,12 +1,12 @@
 ##**RPCD Tutorial Part 2**
 
-In this tutorial we will show you how to make your own an executable shell script for the ubus.  We also recommend reading the OpenWRT wiki on the topic aswell, which can be found [here](https://wiki.openwrt.org/doc/techref/rpcd). 
+In this tutorial we will show you how to make your own an executable shell script for the ubus.  We also recommend reading the OpenWRT wiki on the topic aswell, which can be found [here](https://wiki.openwrt.org/doc/techref/rpcd).
 
-Additionally, users should also be familiar with JSON formatting as this is the format used for passing information into UBUS services. Refer to this [link](http://www.w3schools.com/json/) for a brief overview of json formatting. 
+Additionally, users should also be familiar with JSON formatting as this is the format used for passing information into UBUS services. Refer to this [link](http://www.w3schools.com/json/) for a brief overview of json formatting.
 
 ###**UBUS Shell Scripts**
 
-There are two distinguishing features that seperate ubus shell scripts from regular shell scripts, which we will become evident in our example. 
+There are two distinguishing features that seperate ubus shell scripts from regular shell scripts, which we will become evident in our example.
 
 1) I/O
 
@@ -16,7 +16,7 @@ All input/output of _ubus_ shell scripts are in the form of JSON format. This fo
 
 2) List and Call functions.
 
-A ubus shell script must also support call and list functions to be attached to the ubus. Remember from the first ubus [tutorial](Hyperlink to the first ubus tutorial), that we used the _ubus_ list function to show us how to use the service and we used the _ubus_ call to actually access the service. Both of these functionalities are described in the shell script. 
+A ubus shell script must also support call and list functions to be attached to the ubus. Remember from the first ubus [tutorial](Hyperlink to the first ubus tutorial), that we used the _ubus_ list function to show us how to use the service and we used the _ubus_ call to actually access the service. Both of these functionalities are described in the shell script.
 
 ###**Example**
 
@@ -26,7 +26,7 @@ So to start lets navigate to our rpcd directory.
 
 <pre><code>cd /usr/libexec/rpcd</code></pre>
 
-Now create a file called Math using _cat_ 
+Now create a file called Math using _cat_
 
 <pre><code>cat > Math</code></pre>
 
@@ -34,7 +34,7 @@ And paste the following code
 
 <pre><code>#!/bin/sh
 . /usr/lib/onion/lib.sh  
-    #includes the functions that we need to parse JSON files 
+    #includes the functions that we need to parse JSON files
 
 case "$1" in
     #The list function describes how to use the ubus functions.
@@ -80,25 +80,27 @@ case "$1" in
 esac
 </code></pre>
 
-Once you have pasted the code, press the CTRL D and save the file. 
+Once you have pasted the code, press the CTRL D and save the file.
 
 Once your done that make the file executable by changing the permission on the file enter this into your command line.
 
 <pre><code>chmod +x Math</code></pre>
 
-after that you'll need to reload the rcpd plugin so that it recognizes the new service we have just attached. To do that enter this into your command line.
+after that you'll need to reload the rcpd plugin so that it recognizes the new service we have just attached. To do that either enter this into your command line.
 
-<pre><code>/etc/init.d/rpcd reload</code></pre>
+<pre><code>/etc/init.d/rpcd restart</code></pre>
 
 This should attach your service to the ubus.
+(if not, try running `rpcd` first with the option `stop` and then with the option `start`)
+
 
 ![RPCD2](http://i.imgur.com/mcdiKW3.png)
 
-Now lets check to see if our service is listed.  To check if your service is available enter _ubus_ list into your command line. If that does not work try restarting your Omega, the Math service should now be connected to the plugin. 
+Now lets check to see if our service is listed.  To check if your service is available enter _ubus_ list into your command line. If that does not work check out the other options of rpcd by running `/etc/init.d/rpcd` or try restarting your Omega, the Math service should now be connected to the plugin.
 
 ![RPCD3](http://i.imgur.com/Ys2ZbeV.png)
 
-As you can see, we have _Math_ listed in our ubus service. Let's try using, go ahead and enter the following command and see if it works. 
+As you can see, we have _Math_ listed in our ubus service. Let's try using, go ahead and enter the following command and see if it works.
 
 <pre><code>ubus list -v Math</code></pre>
 <pre><code>ubus call Math addition '{"argument1":"4","argument2":"6"}'</code></pre>
@@ -106,4 +108,4 @@ As you can see, we have _Math_ listed in our ubus service. Let's try using, go a
 
 ![RPCD4](http://i.imgur.com/zKpubtZ.png)
 
-That wraps up our mini-series on Ubus. 
+That wraps up our mini-series on Ubus.


### PR DESCRIPTION
Noticed that rpcd restart does not (always) seem to work. 
Added a note to point ot the other option to use `rpcd start` and `rpcd stop` commands. 
As that is better than having to restart the Omega. 
